### PR TITLE
Update Electron main process to detect dev mode

### DIFF
--- a/horary78-main/frontend/main.js
+++ b/horary78-main/frontend/main.js
@@ -2,9 +2,19 @@ const { app, BrowserWindow } = require('electron');
 const path = require('path');
 const { spawn } = require('child_process');
 
+// Determine if we are running in development mode.
+const isDev = !app.isPackaged;
+
 function createWindow() {
   const win = new BrowserWindow({ width: 800, height: 600 });
-  win.loadFile(path.join(__dirname, 'dist/index.html'));
+
+  if (isDev) {
+    // In development we load the Vite dev server.
+    win.loadURL('http://localhost:3000');
+  } else {
+    // In production we load the built index.html.
+    win.loadFile(path.join(__dirname, 'dist/index.html'));
+  }
 }
 
 app.whenReady().then(() => {


### PR DESCRIPTION
## Summary
- detect development mode in the Electron `main.js`
- load the dev server when running in development
- fall back to bundled `index.html` in production

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684554077ffc8324b82403a378fbabba